### PR TITLE
Refine service usage and add contribution guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+*.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS Instructions
+
+- Keep code formatted with 4 spaces and follow PEP 8 style.
+- Prefer modern type hints using built-in generics (e.g., `list[str]`).
+- After modifying code, install dependencies with `pip install -e .` if needed and run `pytest -q`.
+- When editing service files, use the `fanctrl` console script and avoid unnecessary settings like a working directory.

--- a/fanctrl.service
+++ b/fanctrl.service
@@ -3,8 +3,7 @@ Description=FAN Controller
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/python3 -u fanctrl.py
-WorkingDirectory=/home/pi/fc/
+ExecStart=/usr/bin/fanctrl
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=fanctrl

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS Instructions
+
+- All Python modules must include a module-level docstring and type annotations.
+- Remove unused imports and prefer built-in generics for type hints.
+- Keep imports sorted and grouped (stdlib, third-party, local).

--- a/src/fanctrl/controller.py
+++ b/src/fanctrl/controller.py
@@ -6,7 +6,6 @@ import configparser
 import logging
 import os
 import time
-from typing import Tuple
 
 try:
     import RPi.GPIO as GPIO
@@ -59,7 +58,7 @@ def get_cpu_temp() -> float:
     raise RuntimeError("No CPU temperature sensor found")
 
 
-def get_system_load() -> Tuple[str, str, str]:
+def get_system_load() -> tuple[str, str, str]:
     """Return 1, 5 and 15 minute system loads formatted as strings."""
     load1, load5, load15 = os.getloadavg()
     return tuple(f"{v:.2f}" for v in (load1, load5, load15))


### PR DESCRIPTION
## Summary
- Use modern built-in type hints in controller
- Update systemd unit to invoke installed `fanctrl` script
- Add AGENTS guidelines and ignore build artefacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ab2723244832980a8b16c9ae1ac5d